### PR TITLE
fix: 释放 docx2pdf 转换后的 Word 文件资源

### DIFF
--- a/poword/core/WordType.py
+++ b/poword/core/WordType.py
@@ -70,8 +70,12 @@ class MainWord():
         word_app.Visible = False
         # 打开Word文档，设置为只读模式
         doc = word_app.Documents.Open(wordPath, ReadOnly=1)
-        # 将Word文档导出为PDF格式
-        doc.ExportAsFixedFormat(pdfPath, constants.wdExportFormatPDF)
+        try:
+            # 将Word文档导出为PDF格式
+            doc.ExportAsFixedFormat(pdfPath, constants.wdExportFormatPDF)
+        finally:
+            # 无论导出是否成功，都关闭文档并释放源文件占用
+            doc.Close(False)
         # 下面的代码如果取消注释，每次转换后Word将关闭，不适用于批量转换
         # word_app.Quit()
     def merge4docx(self, input_path, output_path, new_word_name):

--- a/tests/test_word_resource_cleanup.py
+++ b/tests/test_word_resource_cleanup.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def load_word_type_module():
+    fake_docx = types.ModuleType("docx")
+    fake_docx.Document = Mock()
+    fake_docx.ImagePart = type("ImagePart", (), {})
+
+    fake_pofile = types.ModuleType("pofile")
+    fake_pofile.get_files = Mock()
+    fake_pofile.mkdir = Mock()
+
+    fake_progress = types.ModuleType("poprogress")
+    fake_progress.simple_progress = lambda items: items
+
+    fake_client = types.ModuleType("win32com.client")
+    fake_client.constants = types.SimpleNamespace(wdExportFormatPDF=17)
+    fake_client.gencache = types.SimpleNamespace(EnsureDispatch=Mock())
+
+    fake_win32com = types.ModuleType("win32com")
+    fake_win32com.client = fake_client
+
+    dependencies = {
+        "docx": fake_docx,
+        "pofile": fake_pofile,
+        "poprogress": fake_progress,
+        "win32com": fake_win32com,
+        "win32com.client": fake_client,
+    }
+    module_path = Path(__file__).parents[1] / "poword" / "core" / "WordType.py"
+    spec = importlib.util.spec_from_file_location("word_type_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+
+    return module
+
+
+class TestCreatePdfResourceCleanup(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.word_type = load_word_type_module()
+
+    def setUp(self):
+        self.document = Mock()
+        self.word_app = Mock()
+        self.word_app.Documents.Open.return_value = self.document
+        self.word_type.gencache.EnsureDispatch = Mock(return_value=self.word_app)
+        self.main_word = self.word_type.MainWord()
+
+    def test_closes_document_after_successful_export(self):
+        self.main_word.createpdf("source.docx", "output.pdf")
+
+        self.document.ExportAsFixedFormat.assert_called_once_with("output.pdf", 17)
+        self.document.Close.assert_called_once_with(False)
+
+    def test_closes_document_when_export_fails(self):
+        self.document.ExportAsFixedFormat.side_effect = RuntimeError("export failed")
+
+        with self.assertRaisesRegex(RuntimeError, "export failed"):
+            self.main_word.createpdf("source.docx", "output.pdf")
+
+        self.document.Close.assert_called_once_with(False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`createpdf` 打开 Word 文档后没有关闭，导致 PDF 转换完成或导出异常后，源 Word 文件仍可能被占用。

## 修改

- 使用 `try/finally` 包裹 PDF 导出逻辑
- 在 `finally` 中调用 `doc.Close(False)`，确保释放源文件
- 增加 mock 单元测试，覆盖导出成功和导出异常两条路径
- 不调用 `Word.Application.Quit()`，保持现有批量转换行为，避免关闭用户已有的 Word 实例

## 测试

```bash
python3 -m unittest tests.test_word_resource_cleanup -v
```

Fixes CoderWanFeng/python-office#123
Related to CoderWanFeng/python-office#122