### PR TITLE
feat: 支持隐藏 doc2docx 转换进度条

### DIFF
--- a/poword/api/word.py
+++ b/poword/api/word.py
@@ -27,8 +27,8 @@ def merge4docx(input_path, output_path, new_word_name):
     mainWord.merge4docx(input_path, output_path, new_word_name)
 
 
-def doc2docx(input_path, output_path, output_name):
-    mainWord.doc2docx(input_path, output_path, output_name)
+def doc2docx(input_path, output_path, output_name, show_progress=True):
+    mainWord.doc2docx(input_path, output_path, output_name, show_progress=show_progress)
 
 
 def docx2doc(input_path, output_path, output_name):

--- a/poword/core/WordType.py
+++ b/poword/core/WordType.py
@@ -123,7 +123,8 @@ class MainWord():
         # 打印合并完成的标志信息
         print('-' * 10 + '合并完成!' + '-' * 10)
 
-    def doc2docx(self, input_path, output_path, output_name=None, docSuffix='.docx', type_id=16):
+    def doc2docx(self, input_path, output_path, output_name=None, docSuffix='.docx', type_id=16,
+                 show_progress=True):
         """
         将doc文件转换为docx文件
         :param input_path: 输入文件的路径
@@ -131,10 +132,11 @@ class MainWord():
         :param output_name: (可选) 输出文件的名称
         :param docSuffix: (可选) 输入文件的后缀，默认为'.doc'
         :param type_id: (可选) 文件类型ID，用于识别文件格式，默认为16，代表存为.docx文件
+        :param show_progress: (可选) 是否显示转换进度条，默认为True
         :return: 无返回值
         """
         # 调用convert4word方法进行文件格式转换
-        self._convert4word(type_id, input_path, output_path, docSuffix, output_name)
+        self._convert4word(type_id, input_path, output_path, docSuffix, output_name, show_progress)
 
     def docx2doc(self, input_path, output_path='./', output_name=None, docSuffix='.doc', type_id=0):
         """
@@ -150,17 +152,20 @@ class MainWord():
         # 调用convert4word方法实现docx到doc的格式转换
         self._convert4word(type_id, input_path, output_path, docSuffix, output_name)
 
-    def _convert4word(self, type_id, input_path, output_path, docSuffix, output_name):
+    def _convert4word(self, type_id, input_path, output_path, docSuffix, output_name,
+                      show_progress=True):
         """
 
         :param type_id: 16-docx,0-doc
+        :param show_progress: 是否显示转换进度条
         :return:
         """
         abs_input_path = Path(input_path).absolute()
         exsit, abs_output_path = mkdir(output_path)
         word_file_list = get_files(abs_input_path, suffix=docSuffix)
         out_suffix = '.doc' if type_id == 0 else '.docx'
-        for word_file in simple_progress(word_file_list):
+        files_to_convert = simple_progress(word_file_list) if show_progress else word_file_list
+        for word_file in files_to_convert:
             # self.convert4word(type_id, abs_input_path, abs_output_path)
             word_app = gencache.EnsureDispatch(self.app)  # 打开word程序
             word_app.Visible = False  # 是否可视化

--- a/tests/test_doc2docx_progress.py
+++ b/tests/test_doc2docx_progress.py
@@ -1,0 +1,68 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def load_word_type_module():
+    fake_docx = types.ModuleType("docx")
+    fake_docx.Document = Mock()
+    fake_docx.ImagePart = type("ImagePart", (), {})
+
+    fake_pofile = types.ModuleType("pofile")
+    fake_pofile.get_files = Mock()
+    fake_pofile.mkdir = Mock()
+
+    fake_progress = types.ModuleType("poprogress")
+    fake_progress.simple_progress = Mock(side_effect=lambda items: items)
+
+    fake_client = types.ModuleType("win32com.client")
+    fake_client.constants = types.SimpleNamespace()
+    fake_client.gencache = types.SimpleNamespace()
+
+    fake_win32com = types.ModuleType("win32com")
+    fake_win32com.client = fake_client
+
+    dependencies = {
+        "docx": fake_docx,
+        "pofile": fake_pofile,
+        "poprogress": fake_progress,
+        "win32com": fake_win32com,
+        "win32com.client": fake_client,
+    }
+    module_path = Path(__file__).parents[1] / "poword" / "core" / "WordType.py"
+    spec = importlib.util.spec_from_file_location("word_type_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+
+    with patch.dict(sys.modules, dependencies):
+        spec.loader.exec_module(module)
+
+    return module
+
+
+class TestDoc2DocxProgress(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.word_type = load_word_type_module()
+
+    def setUp(self):
+        self.word_type.get_files = Mock(return_value=[])
+        self.word_type.mkdir = Mock(return_value=(False, Path("output")))
+        self.word_type.simple_progress = Mock(side_effect=lambda items: items)
+        self.main_word = self.word_type.MainWord()
+
+    def test_shows_progress_by_default(self):
+        self.main_word.doc2docx("source.doc", "output")
+
+        self.word_type.simple_progress.assert_called_once_with([])
+
+    def test_can_hide_progress(self):
+        self.main_word.doc2docx("source.doc", "output", show_progress=False)
+
+        self.word_type.simple_progress.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

为 CoderWanFeng/python-office#139 增加隐藏 `doc2docx` 转换进度条的底层能力。

## 修改

- 为 `poword.doc2docx` 和 `MainWord.doc2docx` 增加 `show_progress=True` 参数
- `show_progress=False` 时跳过 `simple_progress`，直接遍历待转换文件
- 默认值保持为 `True`，不改变现有调用行为
- 增加跨平台 mock 单元测试，覆盖默认显示和显式隐藏两种情况

## 测试

```bash
python3 -m unittest tests.test_doc2docx_progress -v
```

Related to CoderWanFeng/python-office#139